### PR TITLE
Add more alternatives

### DIFF
--- a/rfcs/0001-rfc-process.md
+++ b/rfcs/0001-rfc-process.md
@@ -22,6 +22,8 @@ RISC-V ISA or other aspects of the RISC-V project.
 ## Alternatives
 
 * Phabricator instead of GitHub
+* GitLab instead of GitHub
+* reStructuredText instead of Markdown
 * LaTeX instead of Markdown
 * RFCs are submitted for review on isa-dev mailing list
 * All discussion occurs on isa-dev mailing list


### PR DESCRIPTION
- Python PEPs use reStructuredText (https://www.python.org/dev/peps/pep-0012/ and https://github.com/python/peps/)
- RST could be used for RISC-V documentation (RST/docutils/Sphinx can generate both LaTeX and HTML, is extendible and can represent quite complex documents which is convenient) - so it might make sense to align the two, although this is not a strict necessity

---
- GitLab is a locally-installable clone of GitHub, worth considering. Phabricator on the other hand has more project-management features so I agree it's also interesting.
